### PR TITLE
Increase MaxValueSize for a reasonable value

### DIFF
--- a/ledis/const.go
+++ b/ledis/const.go
@@ -76,7 +76,7 @@ const (
 	MaxSetMemberSize int = 1024
 
 	//max value size
-	MaxValueSize int = 10 * 1024 * 1024
+	MaxValueSize int = 1024 * 1024 * 1024
 )
 
 var (


### PR DESCRIPTION
10MB for a blob is a really tiny size, I'd like to decide myself the size of values I'm going to push. And it seems to me that all blobs smaller than 1GB shouldn't be harmful for the ledis, so just lift up this limit please.
