### PR TITLE
update documentation for using default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,13 @@ If you don't use a configuration, LedisDB will use the default for you.
 
 ## Package Example
     
-    import "github.com/siddontang/ledisdb/ledis"
+    import (
+      lediscfg "github.com/siddontang/ledisdb/config"
+      "github.com/siddontang/ledisdb/ledis"
+    )
+
+    # Use Ledis's default config
+    cfg := lediscfg.NewConfigDefault()
     l, _ := ledis.Open(cfg)
     db, _ := l.Select(0)
 


### PR DESCRIPTION
Hi,

I've just checked out ledisdb quickly today and realised the example for using default configuration for embed use is lacking the step for getting a default cfg. 

It'll be very useful for new comers who want to checkout quickly how ledis works.