### PR TITLE
Unix domain socket permissions settings (issue #203)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -97,6 +97,8 @@ type Config struct {
 
 	Addr string `toml:"addr"`
 
+	AddrUnixSocketPerm string `toml:"addr_unixsocketperm"`
+
 	HttpAddr string `toml:"http_addr"`
 
 	SlaveOf string `toml:"slaveof"`

--- a/config/config.toml
+++ b/config/config.toml
@@ -3,6 +3,10 @@
 # Server listen address
 addr = "127.0.0.1:6380"
 
+# Unix socket permissions, 755 by default.
+# Ignored for tcp socket.
+addr_unixsocketperm = "0770"
+
 # Server http listen address, set empty to disable
 http_addr = "127.0.0.1:11181"
 

--- a/server/app.go
+++ b/server/app.go
@@ -99,7 +99,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 		if perm, err = strconv.ParseInt(cfg.AddrUnixSocketPerm, 8, 32); err != nil {
 			return nil, err
 		}
-		if err = os.Chmod(cfg.Addr, os.FileMode(uint32(perm))); err != nil {
+		if err = os.Chmod(cfg.Addr, os.FileMode(perm)); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Tested it briefly - it changes socket's file permission to the value from config.
Sorry, didn't create unit test.