### PR TITLE
Fix dev.sh when homebrew is missing

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -10,7 +10,7 @@ fi
 
 #default snappy and leveldb install path
 #you may change yourself
-HOMEBREW_PREFIX=$(brew --prefix 2>/dev/null)
+HOMEBREW_PREFIX=$(type brew >/dev/null 2>&1 && brew --prefix 2>/dev/null)
 if [[ ! -z "$HOMEBREW_PREFIX" ]]; then
   SNAPPY_DIR=$HOMEBREW_PREFIX/opt/snappy
   LEVELDB_DIR=$HOMEBREW_PREFIX/opt/leveldb


### PR DESCRIPTION
This should fix the problems @nikolay-turpitko was having running dev.sh on linux.

See commit comments of b78f17aaa08415eed13d898d7781662efd650bec for details.