### PR TITLE
Some additional features for HTTP interface

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"strings"
 	"sync"
 
 	"github.com/BurntSushi/toml"
@@ -88,6 +89,16 @@ type SnapshotConfig struct {
 	MaxNum int    `toml:"max_num"`
 }
 
+type ResponseHeader struct {
+	Key   string
+	Value string
+}
+
+type HTTPConfig struct {
+	ForbidCommands  []string         `toml:"forbid_commands"`
+	ResponseHeaders []ResponseHeader `toml:"response_header"`
+}
+
 type Config struct {
 	m sync.RWMutex `toml:"-"`
 
@@ -124,6 +135,7 @@ type Config struct {
 	Replication    ReplicationConfig `toml:"replication"`
 
 	Snapshot SnapshotConfig `toml:"snapshot"`
+	HTTP     HTTPConfig     `toml:"http"`
 
 	ConnReadBufferSize    int `toml:"conn_read_buffer_size"`
 	ConnWriteBufferSize   int `toml:"conn_write_buffer_size"`
@@ -214,8 +226,8 @@ func getDefault(d int, s int) int {
 
 func (cfg *Config) adjust() {
 	cfg.LevelDB.adjust()
-
 	cfg.RocksDB.adjust()
+	cfg.HTTP.adjust()
 
 	cfg.Replication.ExpiredLogDays = getDefault(7, cfg.Replication.ExpiredLogDays)
 	cfg.Replication.MaxLogFileNum = getDefault(50, cfg.Replication.MaxLogFileNum)
@@ -252,6 +264,12 @@ func (cfg *RocksDBConfig) adjust() {
 	cfg.StatsDumpPeriodSec = getDefault(3600, cfg.StatsDumpPeriodSec)
 	cfg.BackgroundThreads = getDefault(2, cfg.BackgroundThreads)
 	cfg.HighPriorityBackgroundThreads = getDefault(1, cfg.HighPriorityBackgroundThreads)
+}
+
+func (cfg *HTTPConfig) adjust() {
+	for index, command := range cfg.ForbidCommands {
+		cfg.ForbidCommands[index] = strings.ToLower(command)
+	}
 }
 
 func (cfg *Config) Dump(w io.Writer) error {

--- a/etc/ledis.conf
+++ b/etc/ledis.conf
@@ -162,3 +162,14 @@ path = ""
 
 # Reserve newest max_num snapshot dump files
 max_num = 1
+
+[http]
+# HTTP interface
+
+# Additional commands should be disabled
+#forbid_commands = ["flushall", "flushdb"]
+
+# Additional headers in response
+#[[http.response_header]]
+#key = "Access-Control-Allow-Origin"
+#value = "*"

--- a/server/client_http.go
+++ b/server/client_http.go
@@ -132,6 +132,7 @@ func (c *httpClient) parseReqPath(r *http.Request) (db int, cmd string, args []s
 			if err == nil && len(body) > 0 {
 				args = append(args, string(body))
 			}
+			r.Body.Close()
 		}
 	}
 
@@ -191,11 +192,11 @@ func (w *httpWriter) writeBulk(b []byte) {
 
 func (w *httpWriter) writeArray(lst []interface{}) {
 	for i, elem := range lst {
-		switch elem.(type) {
+		switch t := elem.(type) {
 		case []byte:
-			lst[i] = convertBytesToString(elem.([]byte))
+			lst[i] = convertBytesToString(t)
 		case [][]byte:
-			lst[i] = convertBytesSliceToString(elem.([][]byte))
+			lst[i] = convertBytesSliceToString(t)
 		}
 	}
 	w.genericWrite(lst)

--- a/server/client_http.go
+++ b/server/client_http.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -66,6 +67,9 @@ func (c *httpClient) makeRequest(app *App, r *http.Request, w http.ResponseWrite
 	var err error
 
 	db, cmd, argsStr, contentType := c.parseReqPath(r)
+	for _, header := range app.cfg.HTTP.ResponseHeaders {
+		w.Header().Set(header.Key, header.Value)
+	}
 
 	c.db, err = app.ldb.Select(db)
 	if err != nil {
@@ -87,9 +91,13 @@ func (c *httpClient) makeRequest(app *App, r *http.Request, w http.ResponseWrite
 	if _, ok := httpUnsupportedCommands[c.cmd]; ok {
 		return fmt.Errorf("unsupported command: '%s'", cmd)
 	}
+	for _, command := range app.cfg.HTTP.ForbidCommands {
+		if c.cmd == command {
+			return fmt.Errorf("forbid command: '%s'", cmd)
+		}
+	}
 
 	c.args = args
-
 	c.remoteAddr = c.addr(r)
 	c.resp = &httpWriter{contentType, cmd, w}
 	return nil
@@ -113,6 +121,18 @@ func (c *httpClient) parseReqPath(r *http.Request) (db int, cmd string, args []s
 	} else {
 		cmd = substrings[1]
 		args = substrings[2:]
+	}
+
+	if r.Body != nil {
+		// try use body as last argument
+		// when "Content-Type: text/plain"
+		ct := r.Header.Get("Content-Type")
+		if strings.HasPrefix(ct, "text") {
+			body, err := ioutil.ReadAll(r.Body)
+			if err == nil && len(body) > 0 {
+				args = append(args, string(body))
+			}
+		}
 	}
 
 	return

--- a/server/client_http_test.go
+++ b/server/client_http_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -42,10 +43,31 @@ func TestHttp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	b, _ = ioutil.ReadAll(r.Body)
 	r.Body.Close()
 	if string(b) != `{"XSCAN":["",["http_hello"]]}` {
 		t.Fatal("XSCAN result not correct")
+	}
+
+	// use HTTP body as last argument
+	url := fmt.Sprintf("http://%s/SET/http_hello", testApp.cfg.HttpAddr)
+	content := "world2"
+	req, err := http.NewRequest("POST", url, bytes.NewBufferString(content))
+	req.Header.Set("Content-Type", "text/plain")
+	client := &http.Client{}
+	r, err = client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	r, err = http.Get(fmt.Sprintf("http://%s/GET/http_hello", testApp.cfg.HttpAddr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _ = ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	if string(b) != `{"GET":"world2"}` {
+		t.Fatal("SET with HTTP body failed")
 	}
 }

--- a/server/client_http_test.go
+++ b/server/client_http_test.go
@@ -37,4 +37,15 @@ func TestHttp(t *testing.T) {
 		t.Fatal("not equal")
 	}
 
+	// XSCAN should not give BASE64 keys
+	r, err = http.Get(fmt.Sprintf("http://%s/XSCAN/KV/", testApp.cfg.HttpAddr))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, _ = ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	if string(b) != `{"XSCAN":["",["http_hello"]]}` {
+		t.Fatal("XSCAN result not correct")
+	}
 }


### PR DESCRIPTION
I need forbid some commands and specify one response header when using HTTP interface. And when value is too long, I want to set it through request body instead of URL.
Besides, `XSCAN` result keys in HTTP response body were encoded with BASE64, I converted them back to normal strings.
