### PR TITLE
Update build flags for lua (Fix #217)

### DIFF
--- a/vendor/lua/lua.go
+++ b/vendor/lua/lua.go
@@ -8,8 +8,13 @@
 package lua
 
 /*
-#cgo LDFLAGS: -llua
-#cgo linux LDFLAGS: -lm -ldl
+#cgo pkg-config: lua5.1
+#cgo CFLAGS: -Ilua
+#cgo llua LDFLAGS: -llua
+#cgo luaa LDFLAGS: -llua -lm -ldl
+#cgo linux,!llua,!luaa LDFLAGS: -llua5.1
+#cgo darwin,!luaa pkg-config: lua5.1
+#cgo freebsd,!luaa LDFLAGS: -llua-5.1
 
 #include <lua.h>
 #include <stdlib.h>

--- a/vendor/lua/lua.go
+++ b/vendor/lua/lua.go
@@ -12,7 +12,7 @@ package lua
 #cgo CFLAGS: -Ilua
 #cgo llua LDFLAGS: -llua
 #cgo luaa LDFLAGS: -llua -lm -ldl
-#cgo linux,!llua,!luaa LDFLAGS: -llua5.1
+#cgo linux,!llua,!luaa LDFLAGS: -llua5.1 -lm
 #cgo darwin,!luaa pkg-config: lua5.1
 #cgo freebsd,!luaa LDFLAGS: -llua-5.1
 


### PR DESCRIPTION
With theses flags, we can now compile with older and newer version of Ubuntu. I tested with Ubuntu 14.04.3 and CoreOS. :-) 

If anybody can test with Mac OSX and others OS ;-)