### PR TITLE
Command names in the ledis.call() should not be case sensetive #218

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	//	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/siddontang/go/sync2"
@@ -106,6 +107,8 @@ func (c *client) perform() {
 	var err error
 
 	start := time.Now()
+
+	c.cmd = strings.ToLower(c.cmd)
 
 	if len(c.cmd) == 0 {
 		err = ErrEmptyCommand

--- a/server/script_test.go
+++ b/server/script_test.go
@@ -101,6 +101,10 @@ var testScript4 = `
     ledis.call("set", 2, "b")
 `
 
+var testScript5 = `
+    return ledis.call("PING")
+`
+
 func TestLuaCall(t *testing.T) {
 	cfg := config.NewConfigDefault()
 	cfg.Addr = ":11188"
@@ -171,6 +175,16 @@ func TestLuaCall(t *testing.T) {
 		t.Fatal(err)
 	} else if string(v) != "b" {
 		t.Fatal(string(v))
+	}
+
+	err = app.script.l.DoString(testScript5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v = luaReplyToLedisReply(l)
+	if vv := v.(string); vv != "PONG" {
+		t.Fatal(fmt.Sprintf("%v %T", v, v))
 	}
 
 	luaClient.db = nil


### PR DESCRIPTION
This change is for "Command names in the ledis.call() should not be case sensetive" #218