### PR TITLE
Close snapshot and iterator when creating ledis dump

### DIFF
--- a/ledis/dump.go
+++ b/ledis/dump.go
@@ -60,6 +60,7 @@ func (l *Ledis) Dump(w io.Writer) error {
 		l.wLock.Unlock()
 		return err
 	}
+	defer snap.Close()
 
 	l.wLock.Unlock()
 
@@ -72,6 +73,7 @@ func (l *Ledis) Dump(w io.Writer) error {
 	}
 
 	it := snap.NewIterator()
+	defer it.Close()
 	it.SeekToFirst()
 
 	compressBuf := make([]byte, 4096)


### PR DESCRIPTION
Not closing causes a panic during garbage collection in the `Release`  routine.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x48 pc=0xfda0cd]

goroutine 18 [running]:
<snip>/vendor/github.com/syndtr/goleveldb/leveldb.(*memDB).decref(0xc8215442e0)
	<snip>/vendor/github.com/syndtr/goleveldb/leveldb/db_state.go:35 +0x6d
<snip>/vendor/github.com/syndtr/goleveldb/leveldb.(*memdbReleaser).Release.func1()
	<snip>/vendor/github.com/syndtr/goleveldb/leveldb/db_iter.go:32 +0x24
sync.(*Once).Do(0xc82133ed00, 0xc8214e4e08)
	/usr/local/go/src/sync/once.go:44 +0xe4
<snip>/vendor/github.com/syndtr/goleveldb/leveldb.(*memdbReleaser).Release(0xc82133ed00)
	<snip>/vendor/github.com/syndtr/goleveldb/leveldb/db_iter.go:33 +0x40
<snip>/vendor/github.com/syndtr/goleveldb/leveldb/util.(*BasicReleaser).Release(0xc820308680)
	<snip>/vendor/github.com/syndtr/goleveldb/leveldb/util/util.go:53 +0x45
<snip>/vendor/github.com/syndtr/goleveldb/leveldb/memdb.(*dbIter).Release(0xc820308680)
	<snip>/vendor/github.com/syndtr/goleveldb/leveldb/memdb/memdb.go:168 +0x62
<snip>/vendor/github.com/syndtr/goleveldb/leveldb/iterator.(*mergedIterator).Release(0xc820308700)
	<snip>/vendor/github.com/syndtr/goleveldb/leveldb/iterator/merged_iter.go:258 +0x9a
<snip>/vendor/github.com/syndtr/goleveldb/leveldb.(*dbIter).Release(0xc8203b6480)
	<snip>/vendor/github.com/syndtr/goleveldb/leveldb/db_iter.go:341 +0xde
```