### PR TITLE
fix error messages to be redis compliant

### DIFF
--- a/server/client_resp.go
+++ b/server/client_resp.go
@@ -228,7 +228,6 @@ func newWriterRESP(conn net.Conn, size int) *respWriter {
 func (w *respWriter) writeError(err error) {
 	w.buff.Write(hack.Slice("-"))
 	if err != nil {
-		w.buff.WriteByte(' ')
 		w.buff.Write(hack.Slice(err.Error()))
 	}
 	w.buff.Write(Delims)

--- a/server/client_resp_test.go
+++ b/server/client_resp_test.go
@@ -14,8 +14,7 @@ func TestRespWriter(t *testing.T) {
 	}{
 		{
 			v: errors.New("Some error"),
-			//e: "-Some error\r\n", // as described at http://redis.io/topics/protocol
-			e: "- Some error\r\n", // actual
+			e: "-Some error\r\n", // as described at http://redis.io/topics/protocol
 		},
 		{
 			v: "Some status",
@@ -43,8 +42,7 @@ func TestRespWriter(t *testing.T) {
 		},
 		{
 			v: []interface{}{[]interface{}{int64(1), int64(2), int64(3)}, []interface{}{"Foo", errors.New("Bar")}},
-			//e: "*2\r\n*3\r\n:1\r\n:2\r\n:3\r\n*2\r\n+Foo\r\n-Bar\r\n",
-			e: "*2\r\n*3\r\n:1\r\n:2\r\n:3\r\n*2\r\n+Foo\r\n- Bar\r\n",
+			e: "*2\r\n*3\r\n:1\r\n:2\r\n:3\r\n*2\r\n+Foo\r\n-Bar\r\n",
 		},
 	} {
 		w := new(respWriter)
@@ -68,7 +66,7 @@ func TestRespWriter(t *testing.T) {
 		}
 		w.flush()
 		if b.String() != fixture.e {
-			t.Errorf("respWriter, actual: %v, expected: %v", []byte(b.String()), []byte(fixture.e))
+			t.Errorf("respWriter, actual: %q, expected: %q", b.String(), fixture.e)
 		}
 	}
 

--- a/server/cmd_script.go
+++ b/server/cmd_script.go
@@ -3,6 +3,7 @@ package server
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/siddontang/go/hack"
@@ -70,7 +71,7 @@ func evalGenericCommand(c *client, evalSha1 bool) (err error) {
 
 	if global.Type() == lua.LTNil {
 		if evalSha1 {
-			return fmt.Errorf("missing %s script", key)
+			return errors.New("NOSCRIPT no matching script, please use EVAL")
 		}
 
 		val, err := l.LoadString(hack.String(c.args[0]))

--- a/server/cmd_server_test.go
+++ b/server/cmd_server_test.go
@@ -18,7 +18,7 @@ func TestAuth(t *testing.T) {
 
 	// Should error, invalid pass
 	_, err = c1.Do("AUTH", "password")
-	if err.Error() != " authentication failure" {
+	if err.Error() != "authentication failure" {
 		t.Fatal("Expected authentication error:", err)
 	}
 
@@ -27,7 +27,7 @@ func TestAuth(t *testing.T) {
 
 	// Should fail doing a command as we've not authed
 	_, err = c2.Do("GET", "tmp_select_key")
-	if err.Error() != " not authenticated" {
+	if err.Error() != "not authenticated" {
 		t.Fatal("Expected authentication error:", err)
 	}
 
@@ -45,13 +45,13 @@ func TestAuth(t *testing.T) {
 
 	// Log out by sending wrong pass
 	_, err = c2.Do("AUTH", "wrong password")
-	if err.Error() != " authentication failure" {
+	if err.Error() != "authentication failure" {
 		t.Fatal("Expected authentication error:", err)
 	}
 
 	// Should fail doing a command as we're logged out
 	_, err = c2.Do("GET", "tmp_select_key")
-	if err.Error() != " not authenticated" {
+	if err.Error() != "not authenticated" {
 		t.Fatal("Expected authentication error:", err)
 	}
 }


### PR DESCRIPTION
In general error messages shouldn't be important, but some redis libraries do seem to rely on error messages now and then (for some reason).

The biggest issue was that for some reason ledisdb writes a space right after the `-` character, which indicates an error. I hope there is no real reason why you do this, as it breaks any compatibility with redis clients that rely on a non-space error.

Further I modified the error message when evalsha1 fails because no script was already loaded. Apparently some redis clients rely on it to be start with a prefix of `NOSCRIPT `, and as I'm assuming no other clients rely on error messages, it should be fine to change this?

I hope this PR is fine for you @siddontang 