### PR TITLE
TLS support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -87,6 +87,12 @@ type SnapshotConfig struct {
 	MaxNum int    `toml:"max_num"`
 }
 
+type TLS struct {
+	Enabled     bool   `toml:"enabled"`
+	Certificate string `toml:"certificate"`
+	Key         string `toml:"key"`
+}
+
 type AuthMethod func(c *Config, password string) bool
 
 type Config struct {
@@ -135,6 +141,9 @@ type Config struct {
 	ConnKeepaliveInterval int `toml:"conn_keepalive_interval"`
 
 	TTLCheckInterval int `toml:"ttl_check_interval"`
+
+	//tls config
+	TLS TLS `toml:"tls"`
 }
 
 func NewConfigWithFile(fileName string) (*Config, error) {

--- a/config/config.toml
+++ b/config/config.toml
@@ -161,3 +161,8 @@ path = ""
 
 # Reserve newest max_num snapshot dump files
 max_num = 1
+
+[tls]
+enabled = true
+certificate = "test.crt"
+key = "test.key"


### PR DESCRIPTION
Add support for TLS.
by adding this section to the config
```toml
enabled = true
certificate = "/path/to/server.crt"
key = "/path/to/key.crt"
```

> Not all available redis clients support TLS out of the box, for example `github.com/garyburd/redigo` supports it by allowing the user to implement his own dial method as an option, where he can use tls.Dial.
The famous python `redis` module support tls out of the box just by setting `ssl=True`.