### PR TITLE
Add repliaciton master auth support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,7 @@ type ReplicationConfig struct {
 	SyncLog          int    `toml:"sync_log"`
 	Compression      bool   `toml:"compression"`
 	UseMmap          bool   `toml:"use_mmap"`
+	MasterPassword   string `toml:"master_password"`
 }
 
 type SnapshotConfig struct {


### PR DESCRIPTION
When master has password protection, slave can't connect to it successfully. So this PR add the feature in by sending the "auth " command to the master when necessary. 