### PR TITLE
Config: Fix quotes at Readonly attribute

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -118,7 +118,7 @@ type Config struct {
 
 	SlaveOf string `toml:"slaveof"`
 
-	Readonly bool `toml:readonly`
+	Readonly bool `toml:"readonly"`
 
 	DataDir string `toml:"data_dir"`
 


### PR DESCRIPTION
Fixed missed quotes at readonly attribute on Config